### PR TITLE
Add TTS message/audio download & bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <strong>Run AI models directly in your browser - no server required!</strong>
   </p>
   <p>
-    <strong>Version 0.1.1</strong>
+    <strong>Version 0.1.2</strong>
   </p>
   <p>
     A Progressive Web App featuring a chat interface with RAG (Retrieval Augmented Generation) capabilities for document-based Q&A.
@@ -31,6 +31,8 @@
 - **PWA**: Install as a native app on any platform
 - **Multiple File Formats**: Supports TXT, MD, PDF, HTML, JSON, and code files
 - **Document Management**: View, delete individual documents or clear all at once
+- **Download Messages**: Save individual assistant messages as markdown files
+- **Download Audio**: Save generated TTS audio as WAV files
 - **System Status**: Click status indicator to view models, parameters, and document stats
 - **JetBrains Mono Font**: Clean monospace typography throughout the interface
 
@@ -112,6 +114,8 @@ The app includes high-quality text-to-speech functionality powered by Kokoro-82M
 3. **Playback Controls**: Click again to pause/resume playback
 4. **Progress Indicator**: Visual progress bar shows playback position
 5. **Streaming Indicator**: Shows "(streaming...)" for longer messages being generated
+6. **Download Message**: Click the download icon to save the message as a markdown file
+7. **Download Audio**: After TTS generation, click the audio download icon to save as WAV
 
 ### TTS Features
 - **WebGPU Accelerated**: Uses WebGPU for fast audio generation (falls back to WASM)
@@ -127,6 +131,7 @@ The app includes high-quality text-to-speech functionality powered by Kokoro-82M
 - **Offline Capable**: Works offline once the TTS model is cached
 - **High Quality**: Natural-sounding speech synthesis with Kokoro-82M
 - **Smart Mode Selection**: Automatically chooses between direct and streaming generation
+- **Download Audio**: Save generated audio as WAV files for offline listening
 
 ## ⚙️ Configuration
 

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,5 +1,5 @@
 {
-    "version": "0.1.1",
+    "version": "0.1.2",
     "name": "LLM on Web - Local AI Assistant",
     "short_name": "LLM on Web",
     "description": "A private AI assistant that runs entirely in your browser using local language models",

--- a/styles.css
+++ b/styles.css
@@ -1036,6 +1036,45 @@ label.toggle-label {
     border: 1px solid var(--border);
 }
 
+.tts-button-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.tts-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    background: var(--background);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: all var(--transition);
+}
+
+.tts-action-btn:hover {
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+    transform: scale(1.05);
+}
+
+.tts-action-btn:active {
+    transform: scale(0.98);
+}
+
+.download-audio-btn {
+    animation: fadeInScale 0.3s ease;
+}
+
+@keyframes fadeInScale {
+    from { opacity: 0; transform: scale(0.8); }
+    to { opacity: 1; transform: scale(1); }
+}
+
 .tts-button {
     display: inline-flex;
     align-items: center;
@@ -1143,6 +1182,16 @@ label.toggle-label {
     .tts-button {
         width: 36px;
         height: 36px;
+    }
+
+    .tts-action-btn {
+        width: 32px;
+        height: 32px;
+    }
+
+    .tts-action-btn svg {
+        width: 14px;
+        height: 14px;
     }
 
     .tts-progress-bar {

--- a/sw.js
+++ b/sw.js
@@ -8,7 +8,7 @@ const logger = {
     debug: LOGGING_ENABLED ? console.debug.bind(console) : () => {}
 };
 
-const VERSION = '0.1.1';
+const VERSION = '0.1.2';
 const CACHE_NAME = `llm-web-v${VERSION}`;
 const APP_SHELL_FILES = [
     '/',

--- a/tts/tts-ui.js
+++ b/tts/tts-ui.js
@@ -6,6 +6,8 @@ class TTSUI {
     constructor() {
         this.activePlayers = new Map();
         this.activeButtons = new Map();
+        this.audioData = new Map();
+        this.downloadAudioBtns = new Map();
         this.isModelLoading = false;
     }
 
@@ -13,6 +15,27 @@ class TTSUI {
         const container = document.createElement('div');
         container.className = 'tts-controls';
 
+        // Button row: [Download Chat] [TTS Play/Pause] [Download Audio]
+        const buttonRow = document.createElement('div');
+        buttonRow.className = 'tts-button-row';
+
+        // Download Chat button
+        const downloadChatBtn = document.createElement('button');
+        downloadChatBtn.className = 'tts-action-btn download-chat-btn';
+        downloadChatBtn.setAttribute('aria-label', 'Download message as markdown');
+        downloadChatBtn.title = 'Download message';
+        downloadChatBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+            <polyline points="14 2 14 8 20 8"/>
+            <line x1="16" y1="13" x2="8" y2="13"/>
+            <line x1="16" y1="17" x2="8" y2="17"/>
+            <polyline points="10 9 9 9 8 9"/>
+        </svg>`;
+        downloadChatBtn.addEventListener('click', () => {
+            this.handleDownloadChat(messageContent, messageId);
+        });
+
+        // TTS Play/Pause button (existing)
         const button = document.createElement('button');
         button.className = 'tts-button';
         button.setAttribute('aria-label', 'Play text-to-speech');
@@ -22,17 +45,28 @@ class TTSUI {
             <path d="M8 5v14l11-7z"/>
         </svg>`;
 
-        const pauseIcon = `<svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/>
-        </svg>`;
-
-        const loadingIcon = `<svg class="tts-loading-spinner" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="10" stroke-dasharray="32" stroke-dashoffset="32">
-                <animate attributeName="stroke-dashoffset" dur="1.5s" repeatCount="indefinite" from="32" to="0"/>
-            </circle>
-        </svg>`;
-
         button.innerHTML = playIcon;
+
+        // Download Audio button (hidden initially)
+        const downloadAudioBtn = document.createElement('button');
+        downloadAudioBtn.className = 'tts-action-btn download-audio-btn';
+        downloadAudioBtn.setAttribute('aria-label', 'Download audio as WAV');
+        downloadAudioBtn.title = 'Download audio';
+        downloadAudioBtn.style.display = 'none';
+        downloadAudioBtn.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="7 10 12 15 17 10"/>
+            <line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>`;
+        downloadAudioBtn.addEventListener('click', () => {
+            this.handleDownloadAudio(messageId);
+        });
+
+        this.downloadAudioBtns.set(messageId, downloadAudioBtn);
+
+        buttonRow.appendChild(downloadChatBtn);
+        buttonRow.appendChild(button);
+        buttonRow.appendChild(downloadAudioBtn);
 
         // Create progress container
         const progressContainer = document.createElement('div');
@@ -51,7 +85,7 @@ class TTSUI {
         progressContainer.appendChild(progressBar);
         progressContainer.appendChild(progressText);
 
-        container.appendChild(button);
+        container.appendChild(buttonRow);
         container.appendChild(progressContainer);
 
         button.addEventListener('click', async () => {
@@ -59,6 +93,47 @@ class TTSUI {
         });
 
         return container;
+    }
+
+    handleDownloadChat(messageContent, messageId) {
+        const blob = new Blob([messageContent], { type: 'text/markdown' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `message-${messageId}.md`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    handleDownloadAudio(messageId) {
+        const data = this.audioData.get(messageId);
+        if (!data || !data.complete || data.wavBuffers.length === 0) return;
+
+        let wavBuffer;
+        if (data.wavBuffers.length === 1) {
+            wavBuffer = data.wavBuffers[0];
+        } else {
+            wavBuffer = combineWavBuffers(data.wavBuffers);
+        }
+
+        const blob = new Blob([wavBuffer], { type: 'audio/wav' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `audio-${messageId}.wav`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    showDownloadAudioButton(messageId) {
+        const btn = this.downloadAudioBtns.get(messageId);
+        if (btn) {
+            btn.style.display = 'inline-flex';
+        }
     }
 
     async handleButtonClick(button, messageContent, messageId, progressFill, progressText) {
@@ -84,6 +159,13 @@ class TTSUI {
     async startTTS(button, messageContent, messageId, progressFill, progressText) {
         try {
             const textContent = this.prepareTextForTTS(messageContent);
+
+            // Clear previous audio data and hide download button for fresh generation
+            this.audioData.set(messageId, { wavBuffers: [], complete: false });
+            const downloadBtn = this.downloadAudioBtns.get(messageId);
+            if (downloadBtn) {
+                downloadBtn.style.display = 'none';
+            }
 
             if (!ttsEngine.isReady()) {
                 this.updateButtonIcon(button, 'loading');
@@ -144,13 +226,53 @@ class TTSUI {
                 logger.log('[TTS UI] Using streaming playback mode');
                 this.updateButtonIcon(button, 'pause');
 
-                // Initialize streaming playback
-                await player.initializeStreamingPlayback(result);
+                // Wrap the generator to intercept audio chunks for download
+                const audioDataEntry = this.audioData.get(messageId);
+                const self = this;
+                const wrappedGenerator = async function* () {
+                    try {
+                        for await (const audioChunk of result) {
+                            // Capture WAV data for download
+                            try {
+                                if (audioChunk.toWav) {
+                                    const wavBuffer = audioChunk.toWav();
+                                    audioDataEntry.wavBuffers.push(wavBuffer);
+                                }
+                            } catch (err) {
+                                logger.error('[TTS UI] Failed to capture WAV chunk:', err);
+                            }
+                            yield audioChunk;
+                        }
+                        // Generator exhausted — all chunks captured
+                        audioDataEntry.complete = true;
+                        self.showDownloadAudioButton(messageId);
+                    } catch (err) {
+                        // If generator breaks (abort), don't mark complete
+                        logger.log('[TTS UI] Streaming generator interrupted:', err);
+                    }
+                }();
+
+                await player.initializeStreamingPlayback(wrappedGenerator);
             } else if (Array.isArray(result)) {
                 // Handle array of audio chunks (non-streaming mode)
                 if (result.length === 0) {
                     throw new Error('No audio chunks generated');
                 }
+
+                // Capture WAV data from all chunks
+                const audioDataEntry = this.audioData.get(messageId);
+                for (const chunk of result) {
+                    try {
+                        if (chunk.toWav) {
+                            const wavBuffer = chunk.toWav();
+                            audioDataEntry.wavBuffers.push(wavBuffer);
+                        }
+                    } catch (err) {
+                        logger.error('[TTS UI] Failed to capture WAV chunk:', err);
+                    }
+                }
+                audioDataEntry.complete = true;
+                this.showDownloadAudioButton(messageId);
 
                 if (result.length === 1) {
                     logger.log('[TTS UI] Playing single audio chunk');
@@ -315,12 +437,82 @@ class TTSUI {
         }
         this.activePlayers.clear();
         this.activeButtons.clear();
+        this.audioData.clear();
+        this.downloadAudioBtns.clear();
     }
 
     destroy() {
         this.stopAll();
         ttsEngine.abort();
     }
+}
+
+/**
+ * Combine multiple WAV ArrayBuffers into a single WAV file.
+ * All chunks must share the same audio format (sample rate, channels, bit depth).
+ */
+function combineWavBuffers(wavArrayBuffers) {
+    if (wavArrayBuffers.length === 0) return new ArrayBuffer(0);
+    if (wavArrayBuffers.length === 1) return wavArrayBuffers[0];
+
+    // Parse header from first chunk to get format info
+    const firstView = new DataView(wavArrayBuffers[0]);
+    const audioFormat = firstView.getUint16(20, true);
+    const numChannels = firstView.getUint16(22, true);
+    const sampleRate = firstView.getUint32(24, true);
+    const bitsPerSample = firstView.getUint16(34, true);
+    const bytesPerSample = bitsPerSample / 8;
+    const blockAlign = numChannels * bytesPerSample;
+    const byteRate = sampleRate * blockAlign;
+
+    // Calculate total PCM data size (strip 44-byte header from each chunk)
+    let totalDataSize = 0;
+    for (const buf of wavArrayBuffers) {
+        totalDataSize += buf.byteLength - 44;
+    }
+
+    // Create output buffer: 44-byte header + all PCM data
+    const output = new ArrayBuffer(44 + totalDataSize);
+    const view = new DataView(output);
+    const bytes = new Uint8Array(output);
+
+    // Write WAV header
+    // "RIFF"
+    view.setUint8(0, 0x52); view.setUint8(1, 0x49); view.setUint8(2, 0x46); view.setUint8(3, 0x46);
+    // File size - 8
+    view.setUint32(4, 36 + totalDataSize, true);
+    // "WAVE"
+    view.setUint8(8, 0x57); view.setUint8(9, 0x41); view.setUint8(10, 0x56); view.setUint8(11, 0x45);
+    // "fmt "
+    view.setUint8(12, 0x66); view.setUint8(13, 0x6D); view.setUint8(14, 0x74); view.setUint8(15, 0x20);
+    // fmt chunk size
+    view.setUint32(16, 16, true);
+    // Audio format (preserve from source — 3 for IEEE float from Transformers.js)
+    view.setUint16(20, audioFormat, true);
+    // Number of channels
+    view.setUint16(22, numChannels, true);
+    // Sample rate
+    view.setUint32(24, sampleRate, true);
+    // Byte rate
+    view.setUint32(28, byteRate, true);
+    // Block align
+    view.setUint16(32, blockAlign, true);
+    // Bits per sample
+    view.setUint16(34, bitsPerSample, true);
+    // "data"
+    view.setUint8(36, 0x64); view.setUint8(37, 0x61); view.setUint8(38, 0x74); view.setUint8(39, 0x61);
+    // Data size
+    view.setUint32(40, totalDataSize, true);
+
+    // Copy PCM data from each chunk (skip 44-byte headers)
+    let offset = 44;
+    for (const buf of wavArrayBuffers) {
+        const src = new Uint8Array(buf, 44);
+        bytes.set(src, offset);
+        offset += src.length;
+    }
+
+    return output;
 }
 
 const ttsUI = new TTSUI();
@@ -330,6 +522,8 @@ export function addTTSButton(messageElement, messageContent, messageId) {
     const existingControls = messageElement.querySelector('.tts-controls');
     if (existingControls) {
         existingControls.remove();
+        // Clean up stale Map refs
+        ttsUI.downloadAudioBtns.delete(messageId);
     }
 
     const ttsContainer = ttsUI.createTTSButton(messageContent, messageId);


### PR DESCRIPTION
Introduce download functionality for TTS messages and generated audio: add Download Message and Download Audio buttons to the TTS UI, capture WAV buffers during streaming and non-streaming generation, and provide handlers to save messages as .md and combined WAV files. Add a combineWavBuffers helper to merge WAV chunks, manage audio state with audioData and downloadAudioBtns maps, and show the audio download button once generation is complete. Add corresponding CSS for new buttons and animations, update cleanup logic to clear audio maps, and fix minor UI wiring. Also bump app version to 0.1.2 in README, manifest.webmanifest, and sw.js and update README docs to mention the new download features.